### PR TITLE
 Make amount of tokens in throttle! configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Within your Rails controller:
 To capture that exception, in the controller
 
     rescue_from Prorate::Throttled do |e|
+      response.set_header('Retry-In', e.retry_in_seconds.to_s)
       render nothing: true, status: 429
     end
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Within your Rails controller:
 To capture that exception, in the controller
 
     rescue_from Prorate::Throttled do |e|
-      response.set_header('Retry-In', e.retry_in_seconds.to_s)
+      response.set_header('Retry-After', e.retry_in_seconds.to_s)
       render nothing: true, status: 429
     end
 

--- a/lib/prorate/rate_limit.lua
+++ b/lib/prorate/rate_limit.lua
@@ -35,7 +35,7 @@ local last_updated = tonumber(redis.call("GET", last_updated_key)) or now -- use
 local new_bucket_level = math.max(0, bucket_level - (leak_rate * (now - last_updated)))
 
 if (new_bucket_level + n_tokens) <= max_bucket_capacity then
-  new_bucket_level = new_bucket_level + n_tokens
+  new_bucket_level = math.max(0, new_bucket_level + n_tokens)
   retval = {0, math.ceil(new_bucket_level)}
 else
   redis.call("SETEX", block_key, block_duration, now + block_duration)

--- a/lib/prorate/rate_limit.lua
+++ b/lib/prorate/rate_limit.lua
@@ -14,6 +14,7 @@ local block_key = ARGV[1] .. ".block"
 local max_bucket_capacity = tonumber(ARGV[2])
 local leak_rate = tonumber(ARGV[3])
 local block_duration = tonumber(ARGV[4])
+local n_tokens = tonumber(ARGV[5]) -- How many tokens this call adds to the bucket. Defaults to 1
 local now = tonumber(redis.call("TIME")[1]) --unix timestamp, will be required in all paths
 
 local key_lifetime = math.ceil(max_bucket_capacity / leak_rate)
@@ -23,28 +24,29 @@ if blocked_until then
   return {(tonumber(blocked_until) - now), 0}
 end
 
--- get current bucket level
-local bucket_level = tonumber(redis.call("GET", bucket_level_key))
-if not bucket_level then
-  -- this throttle/identifier combo does not exist yet, so much calculation can be skipped
-  redis.call("SETEX", bucket_level_key, key_lifetime, 1) -- set bucket with initial value
-  retval =  {0, 1}
-else
-  -- if it already exists, do the leaky bucket thing
-  local last_updated = tonumber(redis.call("GET", last_updated_key)) or now -- use sensible default of 'now' if the key does not exist
-  local new_bucket_level = math.max(0, bucket_level - (leak_rate * (now - last_updated)))
+-- get current bucket level. The throttle key might not exist yet in which
+-- case we default to 0
+local bucket_level = tonumber(redis.call("GET", bucket_level_key)) or 0
 
-  if (new_bucket_level + 1) <= max_bucket_capacity then
-    new_bucket_level = new_bucket_level + 1
-    retval = {0, math.ceil(new_bucket_level)}
-  else
-    redis.call("SETEX", block_key, block_duration, now + block_duration)
-    retval = {block_duration, 0}
-  end
-  redis.call("SETEX", bucket_level_key, key_lifetime, new_bucket_level) --still needs to be saved
+-- ...and then perform the leaky bucket fillup/leak. We need to do this also when the bucket has
+-- just been created because the initial n_tokens to add might be so high that it will
+-- immediately overflow the bucket and trigger the throttle, on the first call.
+local last_updated = tonumber(redis.call("GET", last_updated_key)) or now -- use sensible default of 'now' if the key does not exist
+local new_bucket_level = math.max(0, bucket_level - (leak_rate * (now - last_updated)))
+
+if (new_bucket_level + n_tokens) <= max_bucket_capacity then
+  new_bucket_level = new_bucket_level + n_tokens
+  retval = {0, math.ceil(new_bucket_level)}
+else
+  redis.call("SETEX", block_key, block_duration, now + block_duration)
+  retval = {block_duration, 0}
 end
 
--- update last_updated for this bucket, required in all branches
+-- Save the new bucket level
+redis.call("SETEX", bucket_level_key, key_lifetime, new_bucket_level)
+
+-- Record when we updated the bucket so that the amount of tokens leaked
+-- can be correctly determined on the next invocation
 redis.call("SETEX", last_updated_key, key_lifetime, now)
 
 return retval

--- a/lib/prorate/throttle.rb
+++ b/lib/prorate/throttle.rb
@@ -24,17 +24,78 @@ module Prorate
       @leak_rate = limit.to_f / period # tokens per second;
     end
 
+    # Add a value that will be used to distinguish this throttle from others.
+    # It has to be something user- or connection-specific, and multiple
+    # discriminators can be combined:
+    #
+    #    throttle << ip_address << user_agent_fingerprint
+    #
+    # @param discriminator[Object] a Ruby object that can be marshaled
+    #    in an equivalent way between requests, using `Marshal.dump
     def <<(discriminator)
       @discriminators << discriminator
     end
 
-    def throttle!
+    # Applies the throttle and raises a {Throttled} exception if it has been triggered
+    #
+    # Accepts an optional number of tokens to put in the bucket (default is 1).
+    # The effect of `n_tokens:` set to 0 is a "ping".
+    # It makes sure the throttle keys in Redis get created and adjusts the
+    # last invoked time of the leaky bucket. Can be used when a throttle
+    # is applied in a "shadow" fashion. For example, imagine you
+    # have a cascade of throttles with the following block times:
+    #
+    #   Throttle A: [-------]
+    #   Throttle B: [----------]
+    #
+    # You apply Throttle A: and it fires, but when that happens you also
+    # want to enable a throttle that is applied to "repeat offenders" only -
+    # - for instance ones that probe for tokens and/or passwords.
+    #
+    #   Throttle C: [-------------------------------]
+    #
+    # If your "Throttle A" fires, you can trigger Throttle C
+    #
+    #    Throttle A: [-----|-]
+    #    Throttle C: [-----|-------------------------]
+    #
+    # because you know that Throttle A has fired and thus Throttle C comes
+    # into effect.  What you want to do, however, is to fire Throttle C
+    # even though Throttle A: would have unlatched, which would create this
+    # call sequence:
+    #
+    #    Throttle A: [-------]    *(A not triggered)
+    #    Throttle C: [------------|------------------]
+    #
+    # To achieve that you can keep Throttle C alive using #ping!, on every check
+    # that touches Throttle A and/or Throttle C. A ping is effectively
+    # a throttle! call with `n_tokens` of 0 (keeps the leaky bucket registered
+    # but does not add any tokens to it):
+    #
+    #    Throttle A: [------]    *(A not triggered since block period has ended)
+    #    Throttle C: [-----------|(ping)------------------]  C is still blocking
+    #
+    # So you can effectively "keep a throttle alive" without ever triggering it,
+    # or keep it alive in combination with other throttles.
+    #
+    # @param n_tokens[Integer] the number of tokens to put in the bucket. If you are
+    #   using Prorate for rate limiting, and a single request is adding N objects to your
+    #   database for example, you can "top up" the bucket with a set number of tokens
+    #   with a arbitrary ratio - like 1 token per inserted row. Once the bucket fills up
+    #   the Throttled exception is going to be raised. Defaults to 1.
+    def throttle!(n_tokens: 1)
       discriminator = Digest::SHA1.hexdigest(Marshal.dump(@discriminators))
       identifier = [name, discriminator].join(':')
 
       redis.with do |r|
-        logger.info { "Applying throttle counter %s" % name }
-        remaining_block_time, bucket_level = run_lua_throttler(redis: r, identifier: identifier, bucket_capacity: limit, leak_rate: @leak_rate, block_for: block_for)
+        logger.debug { "Applying throttle counter %s" % name }
+        remaining_block_time, bucket_level = run_lua_throttler(
+          redis: r,
+          identifier: identifier,
+          bucket_capacity: limit,
+          leak_rate: @leak_rate,
+          block_for: block_for,
+          n_tokens: n_tokens)
 
         if remaining_block_time > 0
           logger.warn { "Throttle %s exceeded limit of %d in %d seconds and is blocked for the next %d seconds" % [name, limit, period, remaining_block_time] }
@@ -44,19 +105,26 @@ module Prorate
       end
     end
 
-    def run_lua_throttler(redis:, identifier:, bucket_capacity:, leak_rate:, block_for:)
-      redis.evalsha(CURRENT_SCRIPT_HASH, [], [identifier, bucket_capacity, leak_rate, block_for])
+    private
+
+    def run_lua_throttler(redis:, identifier:, bucket_capacity:, leak_rate:, block_for:, n_tokens:)
+      redis.evalsha(CURRENT_SCRIPT_HASH, [], [identifier, bucket_capacity, leak_rate, block_for, n_tokens])
     rescue Redis::CommandError => e
       if e.message.include? "NOSCRIPT"
-        # The Redis server has never seen this script before. Needs to run only once in the entire lifetime of the Redis server (unless the script changes)
-        script_filepath = File.join(__dir__, "rate_limit.lua")
-        script = File.read(script_filepath)
-        raise ScriptHashMismatch if Digest::SHA1.hexdigest(script) != CURRENT_SCRIPT_HASH
-        redis.script(:load, script)
-        redis.evalsha(CURRENT_SCRIPT_HASH, [], [identifier, bucket_capacity, leak_rate, block_for])
+        force_load_lua_throttler_script(redis)
+        retry
       else
         raise e
       end
+    end
+
+    # The Redis server has never seen this script before. Needs to run only once in the entire lifetime
+    # of the Redis server, until the script changes - in which case it will be loaded under a different SHA
+    def force_load_lua_throttler_script(into_redis)
+      lua_script_filepath = File.join(__dir__, "rate_limit.lua")
+      lua_script_source = File.read(lua_script_filepath)
+      raise ScriptHashMismatch if Digest::SHA1.hexdigest(lua_script_source) != CURRENT_SCRIPT_HASH
+      into_redis.script(:load, lua_script_source)
     end
   end
 end

--- a/lib/prorate/throttled.rb
+++ b/lib/prorate/throttled.rb
@@ -1,5 +1,17 @@
+# The Throttled exception gets raised when a throttle is triggered.
+#
+# The exception carries additional attributes which can be used for
+# error tracking and for creating a correct Retry-After HTTP header for
+# a 429 response
 class Prorate::Throttled < StandardError
-  attr_reader :throttle_name, :retry_in_seconds
+  # @attr [String] the name of the throttle (like "shpongs-per-ip").
+  #   Can be used to detect which throttle has fired when multiple
+  #   throttles are used within the same block.
+  attr_reader :throttle_name
+
+  # @attr [Integer] for how long the caller will be blocked, in seconds.
+  attr_reader :retry_in_seconds
+
   def initialize(throttle_name, try_again_in)
     @throttle_name = throttle_name
     @retry_in_seconds = try_again_in


### PR DESCRIPTION
Has two main use cases:

**Ping:** keep a throttle "alive" throughout multiple invocations,
some of which do cause it to increment and some don't.

**Metered rate:** increment by values above 1, for example by 1
for each item added to a cart or for every unit of payload sent
to some (expensive) remote service.