### PR TITLE
Adds remaining_throttle_seconds method

### DIFF
--- a/prorate.gemspec
+++ b/prorate.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency 'wetransfer_style', '0.6.5'
   spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'pry', '~> 0.12.2'
 end


### PR DESCRIPTION
This way, we can communicate how long our end user should keep their calm