### PR TITLE
Introduces the throttle status

### DIFF
--- a/lib/prorate/version.rb
+++ b/lib/prorate/version.rb
@@ -1,3 +1,3 @@
 module Prorate
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/prorate.gemspec
+++ b/prorate.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency 'wetransfer_style', '0.6.5'
   spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'pry', '~> 0.12.2'
 end


### PR DESCRIPTION
The status informs the user whether a throttle is blocked (or open) and
for how many seconds the block will be in place.

Let's say you have an endpoint that not only needs throttling, but you want to ban [credential stuffers](https://en.wikipedia.org/wiki/Credential_stuffing) outright. This is a multi-step process:

1. Respond with a 429 if the discriminators of the request would land in an
  already blocking 'credential-stuffing'-throttle
1. Run your regular throttling
1. Perform your sign in action
1. If the sign in was unsuccessful, add the discriminators to the
  'credential-stuffing'-throttle