### PR TITLE
Add a "naked" LeakyBucket module

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ leaky_bucket.state.level #=> will return 0.0
 leaky_bucket.state.full? #=> will return "false"
 state_after_add = leaky_bucket.put(2) #=> returns a State object_
 state_after_add.full? #=> will return "true"
-state_after_add.level? #=> will return 2.0
+state_after_add.level #=> will return 2.0
 ```
 
 ## Why Lua?

--- a/lib/prorate/leaky_bucket.lua
+++ b/lib/prorate/leaky_bucket.lua
@@ -11,9 +11,13 @@ local bucket_level_key = KEYS[1]
 local last_updated_key = KEYS[2]
 
 local leak_rate = tonumber(ARGV[1])
-local key_lifetime = tonumber(ARGV[2])
-local fillup = tonumber(ARGV[3]) -- How many tokens this call adds to the bucket.
-local bucket_capacity = tonumber(ARGV[4]) -- How many tokens is the bucket allowed to contain
+local fillup = tonumber(ARGV[2]) -- How many tokens this call adds to the bucket.
+local bucket_capacity = tonumber(ARGV[3]) -- How many tokens is the bucket allowed to contain
+
+-- Compute the key TTL for the bucket. We are interested in how long it takes the bucket
+-- to leak all the way to 0, as this is the time when the values stay relevant. We pad with 1 second
+-- to have a little cushion.
+local key_lifetime = math.ceil((bucket_capacity / leak_rate) + 1)
 
 -- Take a timestamp
 local redis_time = redis.call("TIME") -- Array of [seconds, microseconds]

--- a/lib/prorate/leaky_bucket.lua
+++ b/lib/prorate/leaky_bucket.lua
@@ -5,8 +5,11 @@
 -- this is required to be able to use TIME and writes; basically it lifts the script into IO
 redis.replicate_commands()
 
--- Keys are passed separately as Redis ensures that the keys live on the
--- same shard (or at least verifies for it). You have to pass all the keys you intend to touch.
+-- Redis documentation recommends passing the keys separately so that Redis
+-- can - in the future - verify that they live on the same shard of a cluster, and
+-- raise an error if they are not. As far as can be understood this functionality is not
+-- yet present, but if we can make a little effort to make ourselves more future proof
+-- we should.
 local bucket_level_key = KEYS[1]
 local last_updated_key = KEYS[2]
 

--- a/lib/prorate/leaky_bucket.lua
+++ b/lib/prorate/leaky_bucket.lua
@@ -1,0 +1,70 @@
+-- Single threaded Leaky Bucket implementation (without blocking).
+-- args: key_base, leak_rate, bucket_ttl, fillup. To just verify the state of the bucket leak_rate of 0 may be passed.
+-- returns: the leve of the bucket in number of tokens
+
+-- this is required to be able to use TIME and writes; basically it lifts the script into IO
+redis.replicate_commands()
+
+-- Keys are passed separately as Redis ensures that the keys live on the
+-- same shard (or at least verifies for it). You have to pass all the keys you intend to touch.
+local bucket_level_key = KEYS[1]
+local last_updated_key = KEYS[2]
+
+local leak_rate = tonumber(ARGV[1])
+local key_lifetime = tonumber(ARGV[2])
+local fillup = tonumber(ARGV[3]) -- How many tokens this call adds to the bucket.
+local bucket_capacity = tonumber(ARGV[4]) -- How many tokens is the bucket allowed to contain
+
+-- Take a timestamp
+local redis_time = redis.call("TIME") -- Array of [seconds, microseconds]
+local now = tonumber(redis_time[1]) + (tonumber(redis_time[2]) / 1000000)
+
+-- get current bucket level. The throttle key might not exist yet in which
+-- case we default to 0
+local bucket_level = tonumber(redis.call("GET", bucket_level_key)) or 0
+
+-- ...and then perform the leaky bucket fillup/leak. We need to do this also when the bucket has
+-- just been created because the initial fillup to add might be so high that it will
+-- immediately overflow the bucket and trigger the throttle, on the first call.
+local last_updated = tonumber(redis.call("GET", last_updated_key)) or now -- use sensible default of 'now' if the key does not exist
+
+-- Subtract the number of tokens leaked since last call
+local dt = now - last_updated
+local new_bucket_level = bucket_level - (leak_rate * dt) + fillup
+
+-- and _then_ and add the tokens we fillup with. Cap the value to be 0 < capacity
+new_bucket_level = math.max(0, math.min(bucket_capacity, new_bucket_level))
+
+-- Since we return a floating point number string-formatted even if the bucket is full we
+-- have some loss of precision in the formatting, even if the bucket was actually full.
+-- This bit of information is useful to preserve.
+local at_capacity = 0
+if new_bucket_level == bucket_capacity then
+  at_capacity = 1
+end
+
+-- If both the initial level was 0, and the level after putting tokens in is 0 we
+-- can avoid setting keys in Redis at all as this was only a level check.
+if new_bucket_level == 0 and bucket_level == 0 then
+  return {"0.0", at_capacity}
+end
+
+-- Save the new bucket level
+redis.call("SETEX", bucket_level_key, key_lifetime, new_bucket_level)
+
+-- Record when we updated the bucket so that the amount of tokens leaked
+-- can be correctly determined on the next invocation
+redis.call("SETEX", last_updated_key, key_lifetime, now)
+
+-- Most Redis adapters when used with the Lua interface truncate floats
+-- to integers (at least in Python that is documented to be the case in
+-- the Redis ebook here
+-- https://redislabs.com/ebook/part-3-next-steps/chapter-11-scripting-redis-with-lua/11-1-adding-functionality-without-writing-c
+-- We need access to the bucket level as a float value since our leak rate might as well be floating point, and to achieve that
+-- we can go two ways. We can turn the float into a Lua string, and then parse it on the other side, or we can convert it to
+-- a tuple of two integer values - one for the integer component and one for fraction.
+-- Now, the unpleasant aspect is that when we do this we will lose precision - the number is not going to be
+-- exactly equal to capacity, thus we lose the bit of information which tells us whether we filled up the bucket or not.
+-- Also since the only moment we can register whether the bucket is above capacity is now - in this script, since
+-- by the next call some tokens will have leaked.
+return {string.format("%.9f", new_bucket_level), at_capacity}

--- a/lib/prorate/leaky_bucket.rb
+++ b/lib/prorate/leaky_bucket.rb
@@ -26,11 +26,15 @@ module Prorate
       alias_method :full?, :full
 
       # Returns the bucket level of the bucket state as a Float
+      #
+      # @return [Float]
       def to_f
         level.to_f
       end
 
       # Returns the bucket level of the bucket state rounded to an Integer
+      #
+      # @return [Integer]
       def to_i
         level.to_i
       end

--- a/lib/prorate/leaky_bucket.rb
+++ b/lib/prorate/leaky_bucket.rb
@@ -7,12 +7,30 @@ module Prorate
     LUA_SCRIPT_HASH = Digest::SHA1.hexdigest(LUA_SCRIPT_CODE)
 
     class BucketState < Struct.new(:level, :full)
+      # Returns the level of the bucket after the operation on the LeakyBucket
+      # object has taken place. There is a guarantee that no tokens have leaked
+      # from the bucket between the operation and the freezing of the BucketState
+      # struct.
+      #
+      # @!attribute [r] level
+      #   @return [Float]
+
+      # Tells whether the bucket was detected to be full when the operation on
+      # the LeakyBucket was performed. There is a guarantee that no tokens have leaked
+      # from the bucket between the operation and the freezing of the BucketState
+      # struct.
+      #
+      # @!attribute [r] full
+      #   @return [Boolean]
+
       alias_method :full?, :full
 
+      # Returns the bucket level of the bucket state as a Float
       def to_f
         level.to_f
       end
 
+      # Returns the bucket level of the bucket state rounded to an Integer
       def to_i
         level.to_i
       end

--- a/lib/prorate/leaky_bucket.rb
+++ b/lib/prorate/leaky_bucket.rb
@@ -1,0 +1,85 @@
+module Prorate
+
+  # This offers just the leaky bucket implementation with fill control, but without the timed lock.
+  # It does not raise any exceptions, it just tracks the state of a leaky bucket in Redis.
+  class LeakyBucket
+    LUA_SCRIPT_CODE = File.read(File.join(__dir__, "leaky_bucket.lua"))
+    LUA_SCRIPT_HASH = Digest::SHA1.hexdigest(LUA_SCRIPT_CODE)
+
+    class BucketState < Struct.new(:level, :full)
+      alias_method :full?, :full
+
+      def to_f
+        level.to_f
+      end
+
+      def to_i
+        level.to_i
+      end
+    end
+
+    def initialize(redis_key:, leak_rate:, bucket_ttl:, redis:, bucket_capacity:)
+      @redis_key = redis_key
+      @bucket_ttl = bucket_ttl
+      @redis = NullPool.new(redis) unless redis.respond_to?(:with)
+      @leak_rate = leak_rate.to_f
+      @capacity = bucket_capacity.to_f
+    end
+
+    # Places `n` tokens in the bucket.
+    #
+    # @return [BucketState] the state of the bucket after the operation
+    def put(n_tokens)
+      run_lua_bucket_script(n_tokens.to_f)
+    end
+
+    # Returns the current state of the bucket, containing the level and whether the bucket is full
+    #
+    # @return [BucketState] the state of the bucket after the operation
+    def state
+      run_lua_bucket_script(0)
+    end
+
+    # Returns the Redis key for the leaky bucket itself
+    # Note that the key is not guaranteed to contain a value if the bucket has not been filled
+    # up recently.
+    #
+    # @return [String]
+    def leaky_bucket_key
+      "#{@redis_key}.leaky_bucket.bucket_level"
+    end
+
+    # Returns the Redis key under which the last updated time of the bucket gets stored.
+    # Note that the key is not guaranteed to contain a value if the bucket has not been filled
+    # up recently.
+    #
+    # @return [String]
+    def last_updated_key
+      "#{@redis_key}.leaky_bucket.last_updated"
+    end
+
+    private
+
+    def run_lua_bucket_script(n_tokens)
+      @redis.with do |r|
+        begin
+          # The script returns a tuple of "whole tokens, microtokens"
+          # to be able to smuggle the float across (similar to Redis TIME command)
+          level_str, is_full_int = r.evalsha(
+            LUA_SCRIPT_HASH,
+            keys: [leaky_bucket_key, last_updated_key], argv: [@leak_rate, @bucket_ttl, n_tokens, @capacity])
+          BucketState.new(level_str.to_f, is_full_int == 1)
+        rescue Redis::CommandError => e
+          if e.message.include? "NOSCRIPT"
+            # The Redis server has never seen this script before. Needs to run only once in the entire lifetime
+            # of the Redis server, until the script changes - in which case it will be loaded under a different SHA
+            r.script(:load, LUA_SCRIPT_CODE)
+            retry
+          else
+            raise e
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/prorate/leaky_bucket.rb
+++ b/lib/prorate/leaky_bucket.rb
@@ -53,8 +53,8 @@ module Prorate
       end
     end
 
-    def initialize(redis_key:, leak_rate:, redis:, bucket_capacity:)
-      @redis_key = redis_key
+    def initialize(redis_key_prefix:, leak_rate:, redis:, bucket_capacity:)
+      @redis_key_prefix = redis_key_prefix
       @redis = NullPool.new(redis) unless redis.respond_to?(:with)
       @leak_rate = leak_rate.to_f
       @capacity = bucket_capacity.to_f
@@ -80,7 +80,7 @@ module Prorate
     #
     # @return [String]
     def leaky_bucket_key
-      "#{@redis_key}.leaky_bucket.bucket_level"
+      "#{@redis_key_prefix}.leaky_bucket.bucket_level"
     end
 
     # Returns the Redis key under which the last updated time of the bucket gets stored.
@@ -89,7 +89,7 @@ module Prorate
     #
     # @return [String]
     def last_updated_key
-      "#{@redis_key}.leaky_bucket.last_updated"
+      "#{@redis_key_prefix}.leaky_bucket.last_updated"
     end
 
     private

--- a/spec/leaky_bucket_spec.rb
+++ b/spec/leaky_bucket_spec.rb
@@ -15,8 +15,8 @@ describe Prorate::LeakyBucket do
 
     # Since we haven't put in any tokens, asking for the levels should not have created
     # any Redis keys as we do not need them
-    expect(r).not_to be_exists(bucket.leaky_bucket_key)
-    expect(r).not_to be_exists(bucket.last_updated_key)
+    expect(r.get(bucket.leaky_bucket_key)).to be_nil
+    expect(r.get(bucket.last_updated_key)).to be_nil
 
     sleep(0.2) # Bucket should stay empty and not go into negative
     expect(bucket.state.to_f).to be >= 0

--- a/spec/leaky_bucket_spec.rb
+++ b/spec/leaky_bucket_spec.rb
@@ -18,7 +18,7 @@ describe Prorate::LeakyBucket do
 
     25.times do |n|
       it "on iteration #{n} accepts the number of tokens and returns the new bucket level" do
-        bucket_name = generate_random_bucket_name.()
+        bucket_name = generate_random_bucket_name.call
         r = Redis.new
         bucket = described_class.new(redis: r, redis_key_prefix: bucket_name, leak_rate: 0.8, bucket_capacity: 2)
 

--- a/spec/leaky_bucket_spec.rb
+++ b/spec/leaky_bucket_spec.rb
@@ -20,7 +20,7 @@ describe Prorate::LeakyBucket do
       it "on iteration #{n} accepts the number of tokens and returns the new bucket level" do
         bucket_name = generate_random_bucket_name.()
         r = Redis.new
-        bucket = described_class.new(redis: r, redis_key: bucket_name, leak_rate: 0.8, bucket_capacity: 2)
+        bucket = described_class.new(redis: r, redis_key_prefix: bucket_name, leak_rate: 0.8, bucket_capacity: 2)
 
         # Nothing should be written into Redis just when creating the object in Ruby
         expect(r.get(bucket.leaky_bucket_key)).to be_nil

--- a/spec/leaky_bucket_spec.rb
+++ b/spec/leaky_bucket_spec.rb
@@ -2,49 +2,67 @@ require 'spec_helper'
 require 'securerandom'
 
 describe Prorate::LeakyBucket do
-  it 'accepts the number of tokens and returns the new bucket level' do
-    r = Redis.new
-    bucket_name = SecureRandom.uuid
-    bucket = described_class.new(redis: r, redis_key: bucket_name, leak_rate: 0.8, bucket_capacity: 2)
+  describe 'in a happy path' do
+    # There is timing involved in Prorate, and some issues can be intermittent.
+    # To make sure _both_ code and tests are resilient, we should run multiple iterations
+    # of the test and do it in a reproducible way.
+    # one of the ways to make it reproducible is to use random names which are reproduced
+    # with the same RSpec seed
+    randomness = Random.new(RSpec.configuration.seed)
+    generate_random_bucket_name = -> {
+      (1..32).map do
+        # bytes 97 to 122 are printable lowercase a-z
+        randomness.rand(97..122)
+      end.pack("C*")
+    }
 
-    # Nothing should be written into Redis just when creating the object in Ruby
-    expect(r.get(bucket.leaky_bucket_key)).to be_nil
-    expect(r.get(bucket.last_updated_key)).to be_nil
+    25.times do |n|
+      it "on iteration #{n} accepts the number of tokens and returns the new bucket level" do
+        bucket_name = generate_random_bucket_name.()
+        r = Redis.new
+        bucket = described_class.new(redis: r, redis_key: bucket_name, leak_rate: 0.8, bucket_capacity: 2)
 
-    expect(bucket.state.to_f).to be_within(0.00001).of(0)
+        # Nothing should be written into Redis just when creating the object in Ruby
+        expect(r.get(bucket.leaky_bucket_key)).to be_nil
+        expect(r.get(bucket.last_updated_key)).to be_nil
 
-    # Since we haven't put in any tokens, asking for the levels should not have created
-    # any Redis keys as we do not need them
-    expect(r.get(bucket.leaky_bucket_key)).to be_nil
-    expect(r.get(bucket.last_updated_key)).to be_nil
+        expect(bucket.state.to_f).to be_within(0.00001).of(0)
 
-    sleep(0.2) # Bucket should stay empty and not go into negative
-    expect(bucket.state.to_f).to be >= 0
+        # Since we haven't put in any tokens, asking for the levels should not have created
+        # any Redis keys as we do not need them
+        expect(r.get(bucket.leaky_bucket_key)).to be_nil
+        expect(r.get(bucket.last_updated_key)).to be_nil
 
-    # We fill to capacity, and even given the precision constraints we should _first_ leak the
-    # tokens and then fillup (so we should receive a value which is as close to 2 as feasible)
-    bucket_state = bucket.put(5)
-    expect(bucket_state).to be_full
-    expect(bucket_state.level).to be_within(0.005).of(2)
+        sleep(0.2) # Bucket should stay empty and not go into negative
+        expect(bucket.state.to_f).to be >= 0
 
-    # Since we did put in tokens now the keys should have been created
-    expect(r.get(bucket.leaky_bucket_key)).not_to be_nil
-    expect(r.get(bucket.last_updated_key)).not_to be_nil
+        # We fill to capacity, and even given the precision constraints we should _first_ leak the
+        # tokens and then fillup (so we should receive a value which is as close to 2 as feasible)
+        bucket_state = bucket.put(5)
+        expect(bucket_state).to be_full
+        expect(bucket_state.level).to be_within(0.005).of(2)
 
-    sleep(0.5)
-    bucket_state = bucket.state
-    expect(bucket_state).not_to be_full
-    expect(bucket_state.level).to be_within(0.01).of(2 - (0.8 * 0.5))
+        # Since we did put in tokens now the keys should have been created
+        expect(r.get(bucket.leaky_bucket_key)).not_to be_nil
+        expect(r.get(bucket.last_updated_key)).not_to be_nil
 
-    # If we take out tokens ("put" with a negative value) we should ever only end up at 0
-    bucket_state = bucket.put(-20)
-    expect(bucket_state).not_to be_full
-    expect(bucket_state.level).to be_within(0.1).of(0)
+        sleep(0.5)
+        bucket_state = bucket.state
+        expect(bucket_state).not_to be_full
+        expect(bucket_state.level).to be_within(0.01).of(2 - (0.8 * 0.5))
 
-    # Verify the keys are wiped after the automatically computed bucket TTL
-    sleep((2 / 0.8) + 1.5)
+        # If we take out tokens ("put" with a negative value) we should ever only end up at 0
+        bucket_state = bucket.put(-20)
+        expect(bucket_state).not_to be_full
+        expect(bucket_state.level).to be_within(0.1).of(0)
 
-    expect(r.get(bucket.leaky_bucket_key)).to be_nil
-    expect(r.get(bucket.last_updated_key)).to be_nil
+        # We need to make sure the keys which we set have a TTL and that the TTL
+        # is reasonable. We cannot check whether the key has been expired or not because deletion in
+        # Redis is somewhat best-effort - there is no guarantee that something will be deleted at
+        # the given TTL, so testing for it is not very useful
+        expect(r.ttl(bucket.leaky_bucket_key)).to be_within(0.5).of(4)
+        expect(r.ttl(bucket.last_updated_key)).to be_within(0.5).of(4)
+      end
+    end
   end
 end

--- a/spec/leaky_bucket_spec.rb
+++ b/spec/leaky_bucket_spec.rb
@@ -38,7 +38,7 @@ describe Prorate::LeakyBucket do
 
         # We fill to capacity, and even given the precision constraints we should _first_ leak the
         # tokens and then fillup (so we should receive a value which is as close to 2 as feasible)
-        bucket_state = bucket.put(5)
+        bucket_state = bucket.fillup(5)
         expect(bucket_state).to be_full
         expect(bucket_state.level).to be_within(0.005).of(2)
 
@@ -52,7 +52,7 @@ describe Prorate::LeakyBucket do
         expect(bucket_state.level).to be_within(0.01).of(2 - (0.8 * 0.5))
 
         # If we take out tokens ("put" with a negative value) we should ever only end up at 0
-        bucket_state = bucket.put(-20)
+        bucket_state = bucket.fillup(-20)
         expect(bucket_state).not_to be_full
         expect(bucket_state.level).to be_within(0.1).of(0)
 

--- a/spec/leaky_bucket_spec.rb
+++ b/spec/leaky_bucket_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'securerandom'
+
+describe Prorate::LeakyBucket do
+  it 'accepts the number of tokens and returns the new bucket level' do
+    r = Redis.new
+    bucket_name = SecureRandom.uuid
+    bucket = described_class.new(redis: r, redis_key: bucket_name, leak_rate: 0.8, bucket_ttl: 4, bucket_capacity: 2)
+
+    # Nothing should be written into Redis just when creating the object in Ruby
+    expect(r).not_to be_exists(bucket.leaky_bucket_key)
+    expect(r).not_to be_exists(bucket.last_updated_key)
+
+    expect(bucket.state.to_f).to be_within(0.00001).of(0)
+
+    # Since we haven't put in any tokens, asking for the levels should not have created
+    # any Redis keys as we do not need them
+    expect(r).not_to be_exists(bucket.leaky_bucket_key)
+    expect(r).not_to be_exists(bucket.last_updated_key)
+
+    sleep(0.2) # Bucket should stay empty and not go into negative
+    expect(bucket.state.to_f).to be >= 0
+
+    # We fill to capacity, and even given the precision constraints we should _first_ leak the
+    # tokens and then fillup (so we should receive a value which is as close to 2 as feasible)
+    bucket_state = bucket.put(5)
+    expect(bucket_state).to be_full
+    expect(bucket_state.level).to be_within(0.005).of(2)
+
+    # Since we did put in tokens now the keys should have been created
+    expect(r).to be_exists(bucket.leaky_bucket_key)
+    expect(r).to be_exists(bucket.last_updated_key)
+
+    sleep(0.5)
+    bucket_state = bucket.state
+    expect(bucket_state).not_to be_full
+    expect(bucket_state.level).to be_within(0.01).of(2 - (0.8 * 0.5))
+
+    # If we take out tokens ("put" with a negative value) we should ever only end up at 0
+    bucket_state = bucket.put(-20)
+    expect(bucket_state).not_to be_full
+    expect(bucket_state.level).to be_within(0.1).of(0)
+  end
+end


### PR DESCRIPTION
The throttle is very full featured but it also carries a lot
of stuff one doesn't necessarily need. There can be situations where
all you need is a leaky bucket and you want to measure its state,
in terms of tokens present. For example if you want to determine if
a specific item is "hot" without necessarily raising exceptions or
setting extra Redis keys.

Let's see if we can reduce the unit of functionality to just that,
and have a module with less configuration too.