### PR TITLE
Fix bug blocked_until cast to zero

### DIFF
--- a/lib/prorate/rate_limit.lua
+++ b/lib/prorate/rate_limit.lua
@@ -31,7 +31,8 @@ local key_lifetime = math.ceil(max_bucket_capacity / leak_rate)
 
 local blocked_until = redis.call("GET", block_key)
 if blocked_until then
-  return {(tonumber(blocked_until) - now), 0}
+  -- see https://redis.io/docs/manual/programmability/lua-api/ : floats should be returned as strings or they will be cast into integers
+  return {(tostring(tonumber(blocked_until) - now)), -1}
 end
 
 -- get current bucket level. The throttle key might not exist yet in which
@@ -49,7 +50,7 @@ if (new_bucket_level + n_tokens) <= max_bucket_capacity then
   retval = {0, math.ceil(new_bucket_level)}
 else
   redis.call("SETEX", block_key, block_duration, now + block_duration)
-  retval = {block_duration, 0}
+  retval = {tostring(block_duration), -1}
 end
 
 -- Save the new bucket level

--- a/lib/prorate/throttle.rb
+++ b/lib/prorate/throttle.rb
@@ -95,7 +95,7 @@ module Prorate
         block_for: @block_for,
         n_tokens: n_tokens)
 
-      if remaining_block_time > 0
+      if bucket_level == -1
         @logger.warn do
           "Throttle %s exceeded limit of %d in %d seconds and is blocked for the next %d seconds" % [@name, @limit, @period, remaining_block_time]
         end

--- a/lib/prorate/version.rb
+++ b/lib/prorate/version.rb
@@ -1,3 +1,3 @@
 module Prorate
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end

--- a/spec/throttle_spec.rb
+++ b/spec/throttle_spec.rb
@@ -55,6 +55,17 @@ describe Prorate::Throttle do
       }.to raise_error(Prorate::Throttled)
     end
 
+    it 'throttles and raises multiple consecutive exceptions' do
+      t = Prorate::Throttle.new(redis: r, limit: 1, period: 10, block_for: 1, name: throttle_name)
+      t.throttle!
+      expect {
+        t.throttle!
+      }.to raise_error(Prorate::Throttled)
+      expect {
+        t.throttle!
+      }.to raise_error(Prorate::Throttled)
+    end
+
     it 'with n_tokens of 0 simply keeps track of the throttle but does not trigger it' do
       t = Prorate::Throttle.new(redis: r, limit: 2, period: 2, block_for: 5, name: throttle_name)
       t << 'request-id'
@@ -100,7 +111,7 @@ describe Prorate::Throttle do
         3.times { t.throttle! }
       }
     end
-
+    
     it 'applies a long block, even if the rolling window for the throttle is shorter' do
       # Exhaust the request limit
       t = Prorate::Throttle.new(redis: r, limit: 4, period: 1, block_for: 60, name: throttle_name)

--- a/spec/throttle_spec.rb
+++ b/spec/throttle_spec.rb
@@ -111,7 +111,7 @@ describe Prorate::Throttle do
         3.times { t.throttle! }
       }
     end
-    
+
     it 'applies a long block, even if the rolling window for the throttle is shorter' do
       # Exhaust the request limit
       t = Prorate::Throttle.new(redis: r, limit: 4, period: 1, block_for: 60, name: throttle_name)


### PR DESCRIPTION
First of all thanks for the great work.

## Bug 
The lua script returns two values: `remaining_block_time` duration (0 if not blocked) and `bucket_level`. remaining_block_time can be a float. However, see https://redis.io/docs/manual/programmability/lua-api/

> Lua has a single numerical type, Lua numbers. There is no distinction between integers and floats. So we always convert Lua numbers into integer replies, removing the decimal part of the number, if any. If you want to return a Lua float, it should be returned as a string exactly like Redis itself does (see, for instance, the [ZSCORE](https://redis.io/commands/zscore) command).

So as soon as `remaining_block_time` gets below 1, it is cast as zero. And since we only throw an exception if `remaining_block_time` > 0, we don't and all calls to throttle! succeed (even though they shouldn't). See the new spec which fails on the current master branch.

## Fix
First convert `remaining_block_time` into a string as suggested in the documentation. But even this would leave a small bug : see line 52 `redis.call("SETEX", block_key, block_duration, now + block_duration)` => because `now` is computed earlier in the script, for a very short window, on a later call to the script, we may get that `blocked_until-now` is negative, meaning the calls to throttle! will succeed erroneously. Setting the `bucket_levet` at -1 whenever the throttler should be blocked is safer, and will prevent this issue.